### PR TITLE
Admin Mode: Restrict registration to teachers

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,57 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+from fastapi.responses import JSONResponse
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+# Simple session store (in-memory)
+sessions = {}
+
+# Load teacher credentials from JSON file
+TEACHERS_FILE = os.path.join(current_dir, "teachers.json")
+def load_teachers():
+    with open(TEACHERS_FILE, "r") as f:
+        return json.load(f)
+
+def authenticate_teacher(username, password):
+    teachers = load_teachers()
+    for teacher in teachers:
+        if teacher["username"] == username and teacher["password"] == password:
+            return True
+    return False
+
+def is_teacher_logged_in(token):
+    return token in sessions
+@app.post("/login")
+async def login(request: Request):
+    data = await request.json()
+    username = data.get("username")
+    password = data.get("password")
+    if authenticate_teacher(username, password):
+        # Generate a simple token
+        token = f"{username}_token"
+        sessions[token] = username
+        return {"token": token}
+    else:
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
+@app.post("/logout")
+async def logout(request: Request):
+    data = await request.json()
+    token = data.get("token")
+    if token in sessions:
+        del sessions[token]
+        return {"message": "Logged out"}
+    else:
+        raise HTTPException(status_code=401, detail="Invalid session token")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -89,44 +132,34 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
+async def signup_for_activity(activity_name: str, request: Request):
+    """Sign up a student for an activity (teachers only)"""
+    data = await request.json()
+    email = data.get("email")
+    token = data.get("token")
+    if not is_teacher_logged_in(token):
+        raise HTTPException(status_code=403, detail="Only teachers can register students.")
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is not already signed up
     if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
+        raise HTTPException(status_code=400, detail="Student is already signed up")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
+async def unregister_from_activity(activity_name: str, request: Request):
+    """Unregister a student from an activity (teachers only)"""
+    data = await request.json()
+    email = data.get("email")
+    token = data.get("token")
+    if not is_teacher_logged_in(token):
+        raise HTTPException(status_code=403, detail="Only teachers can unregister students.")
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is signed up
     if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+[
+  {"username": "teacher1", "password": "pass123"},
+  {"username": "teacher2", "password": "pass456"}
+]


### PR DESCRIPTION
This PR implements admin mode:
- Adds teacher login API (credentials in teachers.json)
- Only logged-in teachers can register/unregister students for activities
- Session token required for registration/unregistration endpoints

Closes #5